### PR TITLE
Account for universal-argument

### DIFF
--- a/README.org
+++ b/README.org
@@ -62,3 +62,11 @@ others using the global one.
          variable.  It can then be executed via =call-last-kbd-macro=
          (normally bound to `C-x-e'), named via =name-last-kbd-macro=,
          and then inserted into your .emacs via =insert-kbd-macro=.
+** For Contributors
+Installation of the development environment can be done with =cask install=.
+
+Tests are written using [[https://github.com/ecukes/ecukes][ecukes]], and can be run with =cask exec ecukes=.
+
+The script =./testrun.sh= starts an emacs instance in the environment that the
+tests are run under. This instance begins with =dot-mode= loaded, but not turned
+on.

--- a/features/step-definitions/dot-mode-steps.el
+++ b/features/step-definitions/dot-mode-steps.el
@@ -16,7 +16,7 @@
 
 ;; NOTE Don't have a generalised version for see vs only see because espuds
 ;; already has a (Then "^I should see$") step
-(Then "^I should only see\\(?: \"\\(.+\\)\"\\|:\\)$"
+(Then "^I should only see\\(?: \"\\([^\"]*\\)\"\\|:\\)$"
   "Asserts that the current buffer just has some text."
   (lambda (expected)
     (let ((actual (buffer-string))


### PR DESCRIPTION
Hi there,

I've just added a bit of code so that things like  `C-uC-d` are recorded as deleting four characters.

I _think_ it works, but I'd like to try it out for a while before suggesting you merge it.

I'm making the PR now partly to see what opinions you have on the concept, and partly in the hope of getting you to try the code out and see if you notice anything wrong.

Cheers.